### PR TITLE
macx: fix make distclean to remove Xcode-generator artifacts

### DIFF
--- a/Jamulus.pro
+++ b/Jamulus.pro
@@ -235,6 +235,16 @@ win32 {
         SOURCES += src/sound/coreaudio-mac/sound.cpp
     }
 
+    # The Xcode generator (macx-xcode) emits moc/ui/rcc output into the
+    # project root (not under release/), so the default distclean rules
+    # miss them. List them here so `make distclean` removes them after a
+    # spec switch and does not reuse stale generated files. Only apply to
+    # the Makefile generator — the Xcode generator misinterprets the globs
+    # as build inputs.
+    !macx-xcode {
+        QMAKE_DISTCLEAN += moc_*.cpp qrc_*.cpp ui_*.h jamulus_plugin_import.cpp .qmake.stash
+    }
+
 } else:ios {
     CONFIG+=add_ios_ffmpeg_libraries # QTBUG-129651
     QMAKE_ASSET_CATALOGS += src/res/iOSIcons.xcassets


### PR DESCRIPTION
The Xcode generator (macx-xcode) emits moc/ui/rcc output and the Xcode project into the project root (not under release/), so the default distclean rules miss them. After switching specs, stale generated files can cause build breakage.

List the generated files and Xcode project directories in QMAKE_DISTCLEAN so make distclean removes them regardless of which macOS spec created them. Use a recursive delete so the directories are removed as well (QMAKE_DISTCLEAN would otherwise only rm -f).

<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**

<!-- Explain what your PR does -->

CHANGELOG: <!-- Insert a short, end-user understandable sentence in past tense right here, e.g.: Client: Fixed crash when clicking the connect button too fast or SKIP if the change should not be documented in the ChangeLog -->

**Context: Fixes an issue?**

<!-- If this fixes an issue, please write Fixes: <issue number here>; if not, please give your PR a context. -->

**Does this change need documentation? What needs to be documented and how?**

<!-- Most new features should be documented on the website: https://github.com/jamulussoftware/jamuluswebsite/ If you have a proposal what to document, feel free to open a draft PR on the website repo -->

**Status of this Pull Request**

<!-- This might be edited by maintainers. -->
<!-- Proof of concept (not to be merged soon); Working implementation; ... -->

**What is missing until this pull request can be merged?**

<!-- Does it still need more testing; ... -->

## Checklist

<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->

-  [ ] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
-  [ ] I tested my code and it does what I want
-  [ ] My code follows the [style guide](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#source-code-consistency) <!-- You can also check if your code passes clang-format -->
-  [ ] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
-  [ ] I've filled all the content above

<!-- Uncomment the following line if your PR changes platform- or build-specific code: -->
<!-- AUTOBUILD: Please build all targets -->
